### PR TITLE
config: Enable SystemUIDialog volume panel by default

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -162,6 +162,10 @@ PRODUCT_PRODUCT_PROPERTIES += \
 PRODUCT_SYSTEM_PROPERTIES += \
     ro.launcher.blur.appLaunch=false
 
+# Enable SystemUIDialog volume panel
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+    sys.fflag.override.settings_volume_panel_in_systemui=true
+
 PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += vendor/derp/overlay
 PRODUCT_PACKAGE_OVERLAYS += vendor/derp/overlay/common
 


### PR DESCRIPTION
* Although the design is not yet completed, it works just fine and looks way better than the old one.

Change-Id: I4ca6f01909482dbf0d245a25d8253050630e0e7d
Reviewed-on: https://review.statixos.com/c/android_vendor_statix/+/9191
Tested-by: Anay Wadhera <anay1018@gmail.com>
Reviewed-by: Anay Wadhera <anay1018@gmail.com>